### PR TITLE
Expose accessory port to the local network only

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ accessories:
   puny-monitor:
     image: hschne/puny-monitor:latest
     host: <host>
-    port: 4567
+    port: "127.0.0.1:4567:4567"
     volumes:
       - /:/host:ro,rslave
       - puny-monitor-data:/puny-monitor/db


### PR DESCRIPTION
Exposed docker ports are publicly accessible since Docker [bypasses UFW rules](https://t.co/2RKbkE0mmG)

This change exposes port 4567 from the accessory only to the local, "kamal" network so the proxy can access it but the public can't